### PR TITLE
fix: correct Zenn syntax error in docker_remotecache.md

### DIFF
--- a/books/e905f2a57b9627/docker_remotecache.md
+++ b/books/e905f2a57b9627/docker_remotecache.md
@@ -15,7 +15,7 @@ DockerのBuildkitにはリモートのキャッシュを使う機能がある。
 > inline and registry exporters both store the cache in the registry. For importing the cache, type=registry is sufficient for both, as specifying the cache format is not necessary.
 
 今回はregistryキャッシュを使う例を紹介する。
-:::massage
+:::message
 registryにしたのはtype=maxをサポートしているため中間imageのキャッシュも使用できるから
 :::
 


### PR DESCRIPTION
Fix typo in Docker remote cache documentation

- Changed `:::massage` to `:::message` on line 18
- This fixes the Zenn message box rendering issue

Closes #56

Generated with [Claude Code](https://claude.ai/code)